### PR TITLE
Removes package-lock.json

### DIFF
--- a/init-project.js
+++ b/init-project.js
@@ -19,4 +19,5 @@ fs.writeFileSync('package.json', newPackageJson)
 fs.writeFileSync('serverless.yml', newServerlessYaml)
 
 fs.writeFileSync('README.md', `#${projectName}`)
+fs.unlinkSync('package-lock.json')
 fs.unlinkSync(__filename)


### PR DESCRIPTION
Otherwise while running `npm install` it will reference the template repo package.json